### PR TITLE
Proper handling of the message payload

### DIFF
--- a/mbc-mailchimp-status.php
+++ b/mbc-mailchimp-status.php
@@ -44,6 +44,7 @@ $config = array(
       'durable' => getenv('MB_USER_MAILCHIMP_STATUS_QUEUE_DURABLE'),
       'exclusive' => getenv('MB_USER_MAILCHIMP_STATUS_QUEUE_EXCLUSIVE'),
       'auto_delete' => getenv('MB_USER_MAILCHIMP_STATUS_QUEUE_AUTO_DELETE'),
+      'bindingKey' => getenv('MB_USER_MAILCHIMP_STATUS_QUEUE_BINDING_KEY'),
     ),
   ),
 );


### PR DESCRIPTION
`$payload` is an object received from rabbit. The actual message we need to unserialize is in `$payload->body`.

A binding key also needed to be set for the queue.

Fixes #3 
